### PR TITLE
add lang attribute to body based on origin; use lang-specific admonition labels

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -213,3 +213,5 @@ page:
   - content: *page_title
     url: *page_url
   navigation: []
+  origin:
+    url: git@github.com:mulesoft/docs-visualizer-jp

--- a/src/css/adoc/admonition-block.css
+++ b/src/css/adoc/admonition-block.css
@@ -47,7 +47,7 @@
     &::before {
       background-image: url(../img/icons/caution.svg);
       color: color-mod(var(--red-3) lightness(40%));
-      content: '注意';
+      content: 'CAUTION';
     }
   }
 
@@ -58,18 +58,18 @@
     &::before {
       background-image: url(../img/icons/important.svg);
       color: color-mod(var(--yellow-3) lightness(40%));
-      content: '重要';
+      content: 'IMPORTANT';
     }
   }
 
   &.note tbody::before {
     background-image: url(../img/icons/note.svg);
-    content: 'メモ';
+    content: 'NOTE';
   }
 
   &.tip tbody::before {
     background-image: url(../img/icons/tip.svg);
-    content: 'ヒント';
+    content: 'TIP';
   }
 
   &.warning tbody {
@@ -79,7 +79,24 @@
     &::before {
       background-image: url(../img/icons/caution.svg);
       color: color-mod(var(--red-3) lightness(40%));
-      content: '警告';
+      content: 'WARNING';
     }
+  }
+}
+body[lang=jp] .admonitionblock {
+  &.caution tbody::before {
+    content: '注意';
+  }
+  &.important tbody::before {
+    content: '重要';
+  }
+  &.note tbody::before {
+    content: 'メモ';
+  }
+  &.tip tbody::before {
+    content: 'ヒント';
+  }
+  &.warning tbody::before {
+    content: '警告';
   }
 }

--- a/src/helpers/includes.js
+++ b/src/helpers/includes.js
@@ -1,0 +1,3 @@
+'use strict'
+  
+module.exports = (haystack, needle) => ~(haystack || '').indexOf(needle)

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -14,7 +14,7 @@
 <meta name="product" content="{{page.component.title}}">
 <meta name="version" content="{{page.version}}">
 {{> head}}
-<body>
+<body{{#if (includes page.origin.url '-jp')}} lang="jp"{{/if}}>
   {{> body-scripts}}
   <section class="flex col">
   {{> header}}


### PR DESCRIPTION
The lang attribute is added to the body automatically if `-jp` is present in the repository name. The Japanese admonition labels are only used if this attribute is present.

(Of course, this opens up other strategies for determining the language of the page).